### PR TITLE
[19] feat: 나라 리스트 api 호출

### DIFF
--- a/src/api/country.ts
+++ b/src/api/country.ts
@@ -1,26 +1,32 @@
 import axios from "axios";
 
+type Data = {
+  "ISO alpha2": string;
+  "ISO alpha3": string;
+  "ISO numeric": number;
+  "대륙명_공통 대륙코드": string;
+  대륙명_행정표준코드: string;
+  "대륙명_외교부 직제": string;
+  영문명: string;
+  한글명: string;
+};
+
 type Country = {
   page: number;
   perPage: number;
   totalCount: number;
   currentCount: number;
   matchCount: number;
-  data: Array<{
-    "ISO alpha2": string;
-    "ISO alpha3": string;
-    "ISO numeric": number;
-    "대륙명_공통 대륙코드": string;
-    대륙명_행정표준코드: string;
-    "대륙명_외교부 직제": string;
-    영문명: string;
-    한글명: string;
-  }>;
+  data: Data[];
 };
 
-export const getCountries = async (): Promise<Country[]> => {
-  const response = await axios.get(
-    `https://api.odcloud.kr/api/15091117/v1/uddi:bbcc2939-88e0-4a54-af03-ab819b4130e6?perPage=196&serviceKey=${process.env.REACT_APP_API_COUNTRY}`
-  );
-  return response.data as Country[];
+export const getCountries = async <T = Country[]>(): Promise<T> => {
+  const API_URL = `https://api.odcloud.kr/api/15091117/v1/uddi:bbcc2939-88e0-4a54-af03-ab819b4130e6?perPage=196&serviceKey=${process.env.REACT_APP_API_COUNTRY}`;
+  try {
+    const response = await axios.get(API_URL);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+    throw Error("나라 정보를 불러오는데 실패했습니다.");
+  }
 };

--- a/src/api/country.ts
+++ b/src/api/country.ts
@@ -1,0 +1,26 @@
+import axios from "axios";
+
+type Country = {
+  page: number;
+  perPage: number;
+  totalCount: number;
+  currentCount: number;
+  matchCount: number;
+  data: Array<{
+    "ISO alpha2": string;
+    "ISO alpha3": string;
+    "ISO numeric": number;
+    "대륙명_공통 대륙코드": string;
+    대륙명_행정표준코드: string;
+    "대륙명_외교부 직제": string;
+    영문명: string;
+    한글명: string;
+  }>;
+};
+
+export const getCountries = async (): Promise<Country[]> => {
+  const response = await axios.get(
+    `https://api.odcloud.kr/api/15091117/v1/uddi:bbcc2939-88e0-4a54-af03-ab819b4130e6?perPage=196&serviceKey=${process.env.REACT_APP_API_COUNTRY}`
+  );
+  return response.data as Country[];
+};


### PR DESCRIPTION
- 나라 호출시 한글과 국가코드를 가져올수 있는 데이터를 호출합니다

- 총 196개의 나라 데이터를 호출합니다.


*** 확인사항 ****

Country type에서 대륙명_행정표준코드, 영문명, 한글명 이부분은 아무리 따옴표를 쳐도 eslint가 따옴표를 없애버리는데 괜찮을까요?
이유를 모르겠습니다.

key값의 경우 .env 파일로 처리를 하였습니다. 

사실 perPage의 기본값은 10개만 나라데이터를 호출합니다. 
그러나 우리의 경우 전체 데이터를 가져오는것이 맞다고 판단이 되어 196개를 한번에 perPage값으로 처리하였습니다. 