### PR TITLE
[32] feat : 예약 탭의 숙소, 액티비티 투어 관련 UI 구현

### DIFF
--- a/public/images/baggage.svg
+++ b/public/images/baggage.svg
@@ -1,0 +1,6 @@
+<svg width="15" height="14" viewBox="0 0 15 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 3.5H3C1.89543 3.5 1 4.39543 1 5.5V11C1 12.1046 1.89543 13 3 13H12C13.1046 13 14 12.1046 14 11V5.5C14 4.39543 13.1046 3.5 12 3.5Z" stroke="black" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4.5 13V3.5" stroke="black" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10.5 13V3.5" stroke="black" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5 3.5C5 2.83696 5.26339 2.20107 5.73223 1.73223C6.20107 1.26339 6.83696 1 7.5 1C8.16304 1 8.79893 1.26339 9.26777 1.73223C9.73661 2.20107 10 2.83696 10 3.5" stroke="black" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/BookDashboard.tsx
+++ b/src/components/BookDashboard.tsx
@@ -1,7 +1,18 @@
 import React from "react";
+import AccommodationList from "./BookingSection/AccommodationList";
+import TourList from "./BookingSection/TourList";
 
 const BookDashboard = () => {
-  return <div>BookDashboard 준비중...</div>;
+  return (
+    <div className="w-full p-10 overflow-auto h-full max-h-[calc(100%-54px)] flex gap-[34px]">
+      <section className="flex-1">
+        <AccommodationList />
+      </section>
+      <section className="flex-1">
+        <TourList />
+      </section>
+    </div>
+  );
 };
 
 export default BookDashboard;

--- a/src/components/BookingSection/AccommodationList.tsx
+++ b/src/components/BookingSection/AccommodationList.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import BookItem from "./BookItem";
+
+const AccommodationList = () => {
+  return (
+    <div className="flex flex-col">
+      <div className="flex justify-between">
+        <span className="text-[22px] font-semibold">숙소</span>
+        <button type="button" aria-label="write">
+          <img
+            className="w-[24px] h-[24px]"
+            src="/images/write.svg"
+            alt="write"
+          />
+        </button>
+      </div>
+      <div className="mb-[40px]">
+        <BookItem />
+        <BookItem />
+        <BookItem />
+      </div>
+    </div>
+  );
+};
+
+export default AccommodationList;

--- a/src/components/BookingSection/BookItem.tsx
+++ b/src/components/BookingSection/BookItem.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+const BookItem = () => {
+  return (
+    <div>
+      <div className="bg-white w-full h-full rounded-3xl p-5 mt-8 flex gap-7 items-center">
+        <div className="w-[80px] flex flex-col items-center gap-5">
+          <div className="flex flex-col items-center">
+            <span className="text-sm text-cool-gray">2024.05</span>
+            <span className="text-3xl text-cool-gray-dart font-bold">05</span>
+            <span className="text-sm text-cool-gray">월요일</span>
+          </div>
+          {/* 액티비티/투어의 경우 이부분이 생략됩니다. 종료데이터가 없으면 안보이도록 처리 */}
+          {/* <span className="text-sky-500 text-xs">(4박)</span>
+          <div className="flex flex-col items-center">
+            <span className="text-sm text-cool-gray">2024.05</span>
+            <span className="text-3xl text-cool-gray-dart font-bold">09</span>
+            <span className="text-sm text-cool-gray">목요일</span>
+          </div> */}
+        </div>
+        <div className="flex flex-col gap-5">
+          {/* 액티비티/투어의 경우 이부분이 생략됩니다.*/}
+          {/* <div className="flex items-center gap-3 ">
+            <img
+              className="w-[20px] h-[20px]"
+              src="/images/baggage.svg"
+              alt="write"
+            />
+            <span className="text-base font-bold">숙소 이름 데이터</span>
+          </div> */}
+          <p>메모내용이 들어갑니다.</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BookItem;

--- a/src/components/BookingSection/BookItem.tsx
+++ b/src/components/BookingSection/BookItem.tsx
@@ -24,7 +24,7 @@ const BookItem = () => {
             <img
               className="w-[20px] h-[20px]"
               src="/images/baggage.svg"
-              alt="write"
+              alt="baggage"
             />
             <span className="text-base font-bold">숙소 이름 데이터</span>
           </div> */}

--- a/src/components/BookingSection/TourList.tsx
+++ b/src/components/BookingSection/TourList.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import BookItem from "./BookItem";
+
+const TourList = () => {
+  return (
+    <div className="flex flex-col">
+      <div className="flex justify-between">
+        <span className="text-[22px] font-semibold">액티비티/투어</span>
+        <button type="button" aria-label="write">
+          <img
+            className="w-[24px] h-[24px]"
+            src="/images/write.svg"
+            alt="write"
+          />
+        </button>
+      </div>
+      <div className="mb-[40px]">
+        <BookItem />
+        <BookItem />
+        <BookItem />
+      </div>
+    </div>
+  );
+};
+
+export default TourList;

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -23,7 +23,7 @@ const Tab = ({ items, onClick, activeTab }: PropsType) => {
           >
             <a
               href="#"
-              className={`w-[100px] inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-blue-500 ${activeTab === tab.key ? "text-gray-800 border-blue-500" : ""} courser-pointer`}
+              className={`w-[100px] inline-block p-4 border-b-2  rounded-t-lg hover:text-gray-600 hover:border-blue-500 ${activeTab === tab.key ? "text-gray-800 border-blue-500" : "border-transparent"} courser-pointer`}
             >
               {tab.title}
             </a>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,8 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        "cool-gray": "#b1b1b1"
+        "cool-gray": "#b1b1b1",
+        "cool-gray-dart": "#a1a1a1"
       }
     }
   },


### PR DESCRIPTION
## 🔎 작업 내용

예약탭의 숙소, 액티비티/투어 관련 UI 레이아웃만 잡아뒀습니다 !
공통컴포넌트로 쓰이는 부분에 분기처리 할 레이아웃은 주석으로 처리해 두었습니다.


  <br/>

## 이미지 첨부

< 종료 날짜가 있는 경우 - 숙소입력과 같이 >
![스크린샷 2024-05-10 02 20 06](https://github.com/FE-MWM/WanderGuide/assets/62421526/ff2ee3da-ebaf-4d06-b759-a6532024babe)
< 종료날자 없는 경우  - 액티비티/투어 > 
![스크린샷 2024-05-10 02 19 41](https://github.com/FE-MWM/WanderGuide/assets/62421526/dad8a730-b72f-42b5-84fc-627f1bcc521e)

<br/>

## 🔧 고민이 되는 부분이나 중점적으로 리뷰받고 싶은 부분 (옵션)

- 내일 할 일을

- 적어주세요

  <br/>

## 🔧 앞으로의 과제 (옵션)

- 내일 할 일을

- 적어주세요

  <br/>

## ➕ 이슈 링크 (옵션)

- [레포 이름 #이슈번호](이슈 주소)

<br/>