### PR TITLE
[39] feat: 메인보드 숙소 , 액티비티/투어 임시데이터 ui 작업

### DIFF
--- a/public/images/arrow-right.svg
+++ b/public/images/arrow-right.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.5 5L15.5 12L8.5 19" stroke="#353F38" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/AccommodationSection/Accommodation.tsx
+++ b/src/components/AccommodationSection/Accommodation.tsx
@@ -23,6 +23,27 @@ const accommodations = [
     nights: "4박", // 계산으로 넣는다고 가정
     name: "숙소 이름 데이터3",
     memo: "메모데이터입니다.데이터길이는 한줄을 넘어가지 않습니다.데이터를 구현합니다."
+  },
+  {
+    startDate: "05/14(월)",
+    endDate: "05/18(목)",
+    nights: "4박", // 계산으로 넣는다고 가정
+    name: "숙소 이름 데이터3",
+    memo: "메모데이터입니다.데이터길이는 한줄을 넘어가지 않습니다.데이터를 구현합니다."
+  },
+  {
+    startDate: "05/14(월)",
+    endDate: "05/18(목)",
+    nights: "4박", // 계산으로 넣는다고 가정
+    name: "숙소 이름 데이터3",
+    memo: "메모데이터입니다.데이터길이는 한줄을 넘어가지 않습니다.데이터를 구현합니다."
+  },
+  {
+    startDate: "05/14(월)",
+    endDate: "05/18(목)",
+    nights: "4박", // 계산으로 넣는다고 가정
+    name: "숙소 이름 데이터3",
+    memo: "메모데이터입니다.데이터길이는 한줄을 넘어가지 않습니다.데이터를 구현합니다."
   }
 ];
 
@@ -68,7 +89,7 @@ const Accommodation = () => {
           </div>
         </div>
         <div className="text-zinc-500 font-bold text-sm text-center mt-[10px] flex items-center gap-2 justify-center">
-          <span>더보기</span>
+          <button type="button">더보기</button>
           <img
             src="/images/arrow-right.svg"
             alt="more"

--- a/src/components/AccommodationSection/Accommodation.tsx
+++ b/src/components/AccommodationSection/Accommodation.tsx
@@ -1,10 +1,36 @@
 import React from "react";
 
+//  임시데이터
+
+const accommodations = [
+  {
+    startDate: "05/14(월)",
+    endDate: "05/18(목)",
+    nights: "4박", // 계산으로 넣는다고 가정
+    name: "숙소 이름 데이터1",
+    memo: "메모데이터입니다.데이터길이는 한줄을 넘어가지 않습니다.데이터를 구현합니다."
+  },
+  {
+    startDate: "05/14(월)",
+    endDate: "05/18(목)",
+    nights: "4박", // 계산으로 넣는다고 가정
+    name: "숙소 이름 데이터2",
+    memo: "메모데이터입니다.데이터길이는 한줄을 넘어가지 않습니다.데이터를 구현합니다."
+  },
+  {
+    startDate: "05/14(월)",
+    endDate: "05/18(목)",
+    nights: "4박", // 계산으로 넣는다고 가정
+    name: "숙소 이름 데이터3",
+    memo: "메모데이터입니다.데이터길이는 한줄을 넘어가지 않습니다.데이터를 구현합니다."
+  }
+];
+
 const Accommodation = () => {
   return (
     <div className="h-full flex flex-col">
       <div className="h-[53px] flex items-center justify-between pb-5">
-        <span className="text-[22px] font-semibold ">숙소</span>
+        <span className="text-[22px] font-semibold">숙소</span>
         <button type="button" aria-label="modify accommodation">
           <img
             className="w-[24px] h-[24px]"
@@ -13,7 +39,43 @@ const Accommodation = () => {
           />
         </button>
       </div>
-      <div className="bg-white w-full h-[calc(100%-53px)] rounded-3xl p-5"></div>
+      <div className="h-full bg-white w-full rounded-3xl p-10">
+        <div className="overflow-hidden h-[90%] max-h-[400px] relative">
+          {accommodations.map((item, index) => (
+            <div
+              key={index}
+              className={`flex flex-col mb-[40px] pb-[40px] ${index === accommodations.length - 1 ? "" : "border-b-2 border-slate-100"}`}
+            >
+              <div className="flex items-center gap-2 mb-[20px]">
+                <span className="text-cool-gray font-extrabold">
+                  {item.startDate} ~ {item.endDate}
+                </span>
+                <span className="text-sky-500">({item.nights})</span>
+              </div>
+              <div className="flex items-center gap-3 mb-[10px]">
+                <img
+                  className="w-[20px] h-[20px]"
+                  src="/images/baggage.svg"
+                  alt="baggage"
+                />
+                <span className="text-base font-bold">{item.name}</span>
+              </div>
+              <span className="text-sm line-clamp-1">{item.memo}</span>
+            </div>
+          ))}
+          <div className="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-b from-transparent to-white indent-[-9999px]">
+            더보기 페이드아웃
+          </div>
+        </div>
+        <div className="text-zinc-500 font-bold text-sm text-center mt-[10px] flex items-center gap-2 justify-center">
+          <span>더보기</span>
+          <img
+            src="/images/arrow-right.svg"
+            alt="more"
+            className="w-[12px] h-[12px]"
+          />
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/AccommodationSection/Accommodation.tsx
+++ b/src/components/AccommodationSection/Accommodation.tsx
@@ -39,7 +39,7 @@ const Accommodation = () => {
           />
         </button>
       </div>
-      <div className="h-full bg-white w-full rounded-3xl p-10">
+      <div className="h-[400px] bg-white w-full rounded-3xl p-10">
         <div className="overflow-hidden h-[90%] max-h-[400px] relative">
           {accommodations.map((item, index) => (
             <div

--- a/src/components/ActivitySection/Activity.tsx
+++ b/src/components/ActivitySection/Activity.tsx
@@ -1,8 +1,24 @@
 import React from "react";
 
+//임시데이터
+const activityList = [
+  {
+    startDate: "05/14(월)",
+    memo: "메모데이터입니다.데이터길이는 한줄을 넘어가지 않습니다.데이터를 구현합니다."
+  },
+  {
+    startDate: "05/14(월)",
+    memo: "메모데이터입니다.데이터길이는 한줄을 넘어가지 않습니다.데이터를 구현합니다."
+  },
+  {
+    startDate: "05/14(월)",
+    memo: "메모데이터입니다.데이터길이는 한줄을 넘어가지 않습니다.데이터를 구현합니다."
+  }
+];
+
 const Activity = () => {
   return (
-    <div className="h-full flex flex-col">
+    <div className="h-full flex flex-col overflow-hidden">
       <div className="h-[53px] flex items-center justify-between pb-5">
         <span className="text-[22px] font-semibold ">액티비티/투어</span>
         <button>
@@ -13,7 +29,30 @@ const Activity = () => {
           />
         </button>
       </div>
-      <div className="bg-white w-full h-[calc(100%-53px)] rounded-3xl p-5"></div>
+      <div className="h-full bg-white w-full  rounded-3xl p-10">
+        <div className="overflow-hidden h-[90%] max-h-[440px] relative">
+          {activityList.map((item, index) => (
+            <div className="flex gap-8 mb-[10px]" key={index}>
+              <span className="text-cool-gray font-extrabold">
+                {item.startDate}
+              </span>
+              <div className="line-clamp-1">{item.memo}</div>
+            </div>
+          ))}
+
+          <div className="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-b from-transparent to-white indent-[-9999px]">
+            더보기 페이드아웃
+          </div>
+        </div>
+        <div className="text-zinc-500	font-bold text-sm text-center mt-[10px] flex items-center gap-2 justify-center ">
+          <span>더보기</span>
+          <img
+            src="/images/arrow-right.svg"
+            alt="more"
+            className="w-[12px] h-[12px]"
+          />
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/ActivitySection/Activity.tsx
+++ b/src/components/ActivitySection/Activity.tsx
@@ -9,34 +9,6 @@ const activityList = [
   {
     startDate: "05/14(월)",
     memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
-  },
-  {
-    startDate: "05/14(월)",
-    memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
-  },
-  {
-    startDate: "05/14(월)",
-    memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
-  },
-  {
-    startDate: "05/14(월)",
-    memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
-  },
-  {
-    startDate: "05/14(월)",
-    memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
-  },
-  {
-    startDate: "05/14(월)",
-    memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
-  },
-  {
-    startDate: "05/14(월)",
-    memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
-  },
-  {
-    startDate: "05/14(월)",
-    memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
   }
 ];
 
@@ -53,7 +25,7 @@ const Activity = () => {
           />
         </button>
       </div>
-      <div className="h-full bg-white w-full  rounded-3xl p-10">
+      <div className="h-[400px] bg-white w-full  rounded-3xl p-10">
         <div className="overflow-hidden h-[90%] max-h-[440px] relative">
           {activityList.map((item, index) => (
             <div className="flex gap-8 mb-[33px]" key={index}>

--- a/src/components/ActivitySection/Activity.tsx
+++ b/src/components/ActivitySection/Activity.tsx
@@ -9,6 +9,30 @@ const activityList = [
   {
     startDate: "05/14(월)",
     memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
+  },
+  {
+    startDate: "05/14(월)",
+    memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
+  },
+  {
+    startDate: "05/14(월)",
+    memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
+  },
+  {
+    startDate: "05/14(월)",
+    memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
+  },
+  {
+    startDate: "05/14(월)",
+    memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
+  },
+  {
+    startDate: "05/14(월)",
+    memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
+  },
+  {
+    startDate: "05/14(월)",
+    memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
   }
 ];
 
@@ -41,7 +65,7 @@ const Activity = () => {
           </div>
         </div>
         <div className="text-zinc-500	font-bold text-sm text-center mt-[10px] flex items-center gap-2 justify-center ">
-          <span>더보기</span>
+          <button type="button">더보기</button>
           <img
             src="/images/arrow-right.svg"
             alt="more"

--- a/src/components/ActivitySection/Activity.tsx
+++ b/src/components/ActivitySection/Activity.tsx
@@ -4,15 +4,35 @@ import React from "react";
 const activityList = [
   {
     startDate: "05/14(월)",
-    memo: "메모데이터입니다.데이터길이는 한줄을 넘어가지 않습니다.데이터를 구현합니다."
+    memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
   },
   {
     startDate: "05/14(월)",
-    memo: "메모데이터입니다.데이터길이는 한줄을 넘어가지 않습니다.데이터를 구현합니다."
+    memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
   },
   {
     startDate: "05/14(월)",
-    memo: "메모데이터입니다.데이터길이는 한줄을 넘어가지 않습니다.데이터를 구현합니다."
+    memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
+  },
+  {
+    startDate: "05/14(월)",
+    memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
+  },
+  {
+    startDate: "05/14(월)",
+    memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
+  },
+  {
+    startDate: "05/14(월)",
+    memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
+  },
+  {
+    startDate: "05/14(월)",
+    memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
+  },
+  {
+    startDate: "05/14(월)",
+    memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
   }
 ];
 
@@ -32,11 +52,11 @@ const Activity = () => {
       <div className="h-full bg-white w-full  rounded-3xl p-10">
         <div className="overflow-hidden h-[90%] max-h-[440px] relative">
           {activityList.map((item, index) => (
-            <div className="flex gap-8 mb-[10px]" key={index}>
+            <div className="flex gap-8 mb-[40px]" key={index}>
               <span className="text-cool-gray font-extrabold">
                 {item.startDate}
               </span>
-              <div className="line-clamp-1">{item.memo}</div>
+              <div className="line-clamp-3">{item.memo}</div>
             </div>
           ))}
 

--- a/src/components/ActivitySection/Activity.tsx
+++ b/src/components/ActivitySection/Activity.tsx
@@ -33,6 +33,10 @@ const activityList = [
   {
     startDate: "05/14(월)",
     memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
+  },
+  {
+    startDate: "05/14(월)",
+    memo: "메모데이터입니다.데이터길이는 세줄을 넘어가지 않습니다.데이터를 구현합니다."
   }
 ];
 
@@ -52,7 +56,7 @@ const Activity = () => {
       <div className="h-full bg-white w-full  rounded-3xl p-10">
         <div className="overflow-hidden h-[90%] max-h-[440px] relative">
           {activityList.map((item, index) => (
-            <div className="flex gap-8 mb-[40px]" key={index}>
+            <div className="flex gap-8 mb-[33px]" key={index}>
               <span className="text-cool-gray font-extrabold">
                 {item.startDate}
               </span>

--- a/src/components/ExchangeRateSection/ExchangeRate.tsx
+++ b/src/components/ExchangeRateSection/ExchangeRate.tsx
@@ -16,7 +16,7 @@ const ExchangeRate = () => {
           <span className="text-xs pl-1">2024.04.20 19:30</span>
         </div>
       </div>
-      <div className="bg-white w-full h-full rounded-3xl p-5"></div>
+      <div className="bg-white w-full h-[83px] rounded-3xl p-5"></div>
     </div>
   );
 };

--- a/src/components/FlightPlansSection/FlightPlans.tsx
+++ b/src/components/FlightPlansSection/FlightPlans.tsx
@@ -13,7 +13,7 @@ const FlightPlans = () => {
           />
         </button>
       </div>
-      <div className="bg-white w-full h-full rounded-3xl p-5"></div>
+      <div className="bg-white w-full h-[564px] rounded-3xl p-5"></div>
     </div>
   );
 };

--- a/src/components/MainDashboard.tsx
+++ b/src/components/MainDashboard.tsx
@@ -10,7 +10,7 @@ import Activity from "./ActivitySection/Activity";
 const MainDashboard = () => {
   return (
     <div className="w-full p-10 overflow-auto h-full max-h-[calc(100%-54px)]">
-      <section className="h-auto pb-1">
+      <section className="h-[90px] pb-1">
         <TravelItinerary />
       </section>
       <div className="flex flex-col h-full gap-7 max-h-[1000px] justify-around">
@@ -22,15 +22,15 @@ const MainDashboard = () => {
             <Weather />
           </div>
         </section>
-        <section className="h-full grid grid-cols-3 gap-6 max-h-[620px]">
-          <div className="col-span-1">
+        <section className="h-full grid grid-cols-3 gap-6 max-h-[720px]">
+          <div className="col-span-1 h-full  pb-[40px]">
             <FlightPlans />
           </div>
           <div className="h-full flex flex-col col-span-2 gap-7 ">
-            <div className="h-1/2">
+            <div>
               <ExchangeRate />
             </div>
-            <div className="h-full grid grid-cols-2 gap-4">
+            <div className="h-full grid grid-cols-2 gap-4 pb-[40px]">
               <Accommodation />
               <Activity />
             </div>

--- a/src/components/Weather/WeatherList.tsx
+++ b/src/components/Weather/WeatherList.tsx
@@ -74,11 +74,11 @@ const WeatherList = ({ setWeatherDate, setRefreshDate }: WeatherProps) => {
 
   return (
     <div className="flex h-full flex-col justify-around">
-      <div className="item-center mb-[15px] flex gap-[2px]">
+      <div className="item-center mb-[15px] flex gap-[10px]">
         <img src="/images/location.svg" alt="location" />
         <span className="text-sm font-bold leading-6 ">{countries}</span>
       </div>
-      <div className="flex gap-[5px] justify-around w-4/5 mx-auto my-0">
+      <div className="flex gap-[5px] justify-around mx-auto my-0">
         {weatherList.map((weather) => (
           <div key={weather.dt} className="flex flex-col items-center">
             <span className="text-blue text-sm ">

--- a/src/page/Home.tsx
+++ b/src/page/Home.tsx
@@ -5,11 +5,11 @@ import Body from "../components/Body";
 
 const Home = () => {
   return (
-    <div className="flex w-full h-full bg-[#f5f7fa] min-w-[1440px] min-h-[800px]">
+    <div className="flex w-full h-full bg-[#f5f7fa]  min-h-[800px] min-w-[1500px]">
       <nav className="w-[230px] h-full">
         <Navbar />
       </nav>
-      <main className="w-[calc(100%-260px)] h-full">
+      <main className="w-[calc(100%-260px)] h-full flex-1">
         <Header />
         <Body />
       </main>


### PR DESCRIPTION


## 🔎 작업 내용


메인보드 임시데이터를 이이용해 UI 구현했습니다. 일정영역까지는 늘어나고 그 이상이 되면 oveflow 되도록 처리하였고
그라데이션 효과로 페이드아웃 나도록 처리하였습니다.
더보기 버튼을 누르면 예약탭으로 이동하면 될것 같습니다 !
임시데이터 부분은 추후 수정해서 사용하면 될것 같습니다.



  <br/>




## 이미지 첨
<img width="1726" alt="스크린샷 2024-05-11 11 25 39" src="https://github.com/FE-MWM/WanderGuide/assets/62421526/99ce9b94-6e25-4c4c-a5d0-82db5e71eb8f">





<img src="파일주소" width="50%" height="50%"/>




<br/>




## 🔧 고민이 되는 부분이나 중점적으로 리뷰받고 싶은 부분 (옵션)




- 내일 할 일을




- 적어주세요




  <br/>




## 🔧 앞으로의 과제 (옵션)




- 내일 할 일을




- 적어주세요




  <br/>




## ➕ 이슈 링크 (옵션)




- [레포 이름 #이슈번호](이슈 주소)




<br/>