### PR TITLE
[12] feat: 환율조회 API 연결

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },
+  "proxy": "https://www.koreaexim.go.kr",
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/src/Util/func.ts
+++ b/src/Util/func.ts
@@ -1,0 +1,37 @@
+import dayjs from "dayjs";
+
+export const dateToString = (date: number) => {
+  if (date < 10) {
+    return `0${date}`;
+  } else {
+    return `${date}`;
+  }
+};
+
+export const getDate = () => {
+  const now = dayjs();
+  if (now.hour() < 11) {
+    // 지금이 오전 11시 이전이라면 어제 날짜를 반환합니다.
+    return now.subtract(1, "day");
+  } else {
+    // 오전 11시 이후라면 오늘 날짜를 반환합니다.
+    return now;
+  }
+};
+
+export const getFridayIfWeekend = (inputDate: Date | string) => {
+  const date = dayjs(inputDate);
+  const dayOfWeek = date.day(); // 일요일=0, 월요일=1, ..., 토요일=6
+
+  if (dayOfWeek === 0) {
+    // 일요일인 경우
+    // 이전 금요일로 설정
+    return date.subtract(2, "day");
+  } else if (dayOfWeek === 6) {
+    // 토요일인 경우
+    // 이전 금요일로 설정
+    return date.subtract(1, "day");
+  }
+  // 주말이 아닌 경우 입력된 날짜를 그대로 반환
+  return date;
+};

--- a/src/api/exchange.ts
+++ b/src/api/exchange.ts
@@ -1,0 +1,18 @@
+import axios from "axios";
+import { getDate, getFridayIfWeekend } from "../Util/func";
+
+export const getExchangeList = async () => {
+  const today = getDate().format("YYYY-MM-DD");
+  const checkWeekend = getFridayIfWeekend(today).format("YYYY-MM-DD");
+  try {
+    const res = axios.get(
+      `/site/program/financial/exchangeJSON?authkey=${process.env.REACT_APP_API_EXCHANGE}&searchdate=${checkWeekend}&data=AP01`
+      //`/site/program/financial/exchangeJSON?authkey=YWVgIoxXxKTI3HNUAZYsfsrV9XTB0WIf&searchdate=20240423&data=AP01`
+    );
+    const req = await res;
+    //console.log("axios", req.data);
+    return req.data;
+  } catch (e) {
+    return false;
+  }
+};

--- a/src/components/ExchangeRateSection/ExchangeRate.tsx
+++ b/src/components/ExchangeRateSection/ExchangeRate.tsx
@@ -1,6 +1,14 @@
 import React from "react";
+import { useGetExchangeRate } from "../../hook/useGetExchangeRate";
 
-const ExchangeRate = () => {
+type ExchangeRateProps = {
+  country: string;
+};
+const ExchangeRate = ({ country }: ExchangeRateProps) => {
+  const { cashData } = useGetExchangeRate(country);
+
+  //console.log(cashData);
+
   return (
     <div className="h-full flex flex-col">
       <div className="h-[53px] flex justify-between items-center pb-5">

--- a/src/components/MainDashboard.tsx
+++ b/src/components/MainDashboard.tsx
@@ -28,7 +28,7 @@ const MainDashboard = () => {
           </div>
           <div className="h-full flex flex-col col-span-2 gap-7 ">
             <div>
-              <ExchangeRate />
+              <ExchangeRate country="싱가포르" />
             </div>
             <div className="h-full grid grid-cols-2 gap-4 pb-[40px]">
               <Accommodation />

--- a/src/hook/useGetExchangeRate.ts
+++ b/src/hook/useGetExchangeRate.ts
@@ -1,0 +1,46 @@
+import { AxiosError } from "axios";
+import { getExchangeList } from "../api/exchange";
+import { useQuery } from "@tanstack/react-query";
+
+type Cash = {
+  result: number;
+  cur_unit: string;
+  ttb: string;
+  tts: string;
+  deal_bas_r: string;
+  bkpr: string;
+  yy_efee_r: string;
+  ten_dd_efee_r: string;
+  kftc_bkpr: "1";
+  kftc_deal_bas_r: string;
+  cur_nm: string;
+};
+
+type CashData = Cash[];
+
+export const useGetExchangeRate = (kor: string) => {
+  //리액트 쿼리로 해당 환율목록 가져오기
+  const { data: cashData } = useQuery<
+    CashData,
+    AxiosError,
+    { krw: string; exc: string }
+  >({
+    queryKey: [`test2`],
+    queryFn: () => getExchangeList(),
+    throwOnError: false,
+    select: (res) => {
+      const exchange = res.find((ele) => {
+        return ele.cur_nm.split(" ")[0] === kor;
+      });
+
+      return {
+        krw: exchange ? exchange.bkpr : "",
+        exc: exchange ? exchange.cur_nm.split(" ")[1] : ""
+      };
+    }
+  });
+
+  //가져온 환율 목록 중 여행할 나라 환율 추출
+
+  return { cashData };
+};


### PR DESCRIPTION
## 🔎 작업 내용

- 환율 조회 api를 연결하니, 주말과 11시 이전은 빈 배열을 줍니다. => 은행 영업일이 아니어서..
그래서 11시 이전이면 어제 날짜 + 어제 날짜가 주말이면 금요일의 환율을 조회하는 기능을 추가하였습니다.

+ .env 파일에 

`REACT_APP_API_EXCHANGE=YWVgIoxXxKTI3HNUAZYsfsrV9XTB0WIf`

이 코드 추가 부탁드립니다!
환율 조회 서비스키입니다

  <br/>

## 이미지 첨부

<img width="753" alt="스크린샷 2024-05-13 오전 3 01 45" src="https://github.com/FE-MWM/WanderGuide/assets/89734122/45b256b6-2f14-453b-92f9-f93f61700816">

 => 오늘은 월요일(13일) 새벽2시 여서 금요일(10일)로 조회
<img width="751" alt="스크린샷 2024-05-13 오전 3 02 14" src="https://github.com/FE-MWM/WanderGuide/assets/89734122/685f328f-5232-40ba-8226-53443392fb85">

<img width="652" alt="스크린샷 2024-05-13 오전 3 01 28" src="https://github.com/FE-MWM/WanderGuide/assets/89734122/e8bd81d4-ddc9-4597-9342-4c1c32270d46">

<br/>

## 🔧 고민이 되는 부분이나 중점적으로 리뷰받고 싶은 부분 (옵션)

 고민이 되는 부분 : 법정공휴일.... 
=> 더 급한 작업 후 시간이 좀 나면, 법정공휴일도 대응하는 함수로 업그레이드 시키겠습니다.

  <br/>

## 🔧 앞으로의 과제 (옵션)

- UI 추가

  <br/>

## ➕ 이슈 링크 (옵션)

- #12 

<br/>

