### PR TITLE
[46] fix : 나라 조회 셀렉트박스 리스트 수정

### DIFF
--- a/src/Util/calcCash.ts
+++ b/src/Util/calcCash.ts
@@ -1,0 +1,5 @@
+export const toNumberCash = (cash: string) => {
+  const stringCash = cash.split(".")[0].replaceAll(",", "");
+  const numberCash = Number(stringCash);
+  return numberCash;
+};

--- a/src/components/CountriesSelectBox.tsx
+++ b/src/components/CountriesSelectBox.tsx
@@ -1,11 +1,8 @@
-import { useRef } from "react";
 import SelectBox from "../context/selectBox/SelectBox";
-import { Data } from "../api/country";
 import { useCountries } from "../hook/useCountries";
 
 const CountriesSelectBox = () => {
   const { value, search } = useCountries();
-  const dataRef = useRef<Data | undefined>();
 
   return (
     <SelectBox>
@@ -21,7 +18,6 @@ const CountriesSelectBox = () => {
                 key={idx}
                 value={`${ele["ISO numeric"]}`}
                 label={ele.한글명}
-                onClick={() => (dataRef.current = ele)}
               >
                 {ele.한글명}
               </SelectBox.item>

--- a/src/components/ExchangeRateSection/ExchangeRate.tsx
+++ b/src/components/ExchangeRateSection/ExchangeRate.tsx
@@ -1,11 +1,8 @@
 import React from "react";
 import { useGetExchangeRate } from "../../hook/useGetExchangeRate";
 
-type ExchangeRateProps = {
-  country: string;
-};
-const ExchangeRate = ({ country }: ExchangeRateProps) => {
-  const { cashData } = useGetExchangeRate(country);
+const ExchangeRate = () => {
+  const { cashData } = useGetExchangeRate();
 
   const list: number[] = [1, 100, 1000, 2000, 5000, 10000, 50000];
 

--- a/src/components/ExchangeRateSection/ExchangeRate.tsx
+++ b/src/components/ExchangeRateSection/ExchangeRate.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useGetExchangeRate } from "../../hook/useGetExchangeRate";
+import NoSettingData from "../common/NoSettingData";
 
 const ExchangeRate = () => {
   const { cashData } = useGetExchangeRate();
@@ -22,17 +23,24 @@ const ExchangeRate = () => {
           <span className="text-xs pl-1">2024.04.20 19:30</span>
         </div> */}
       </div>
-      <div className="bg-white w-full flex flex-row rounded-3xl overflow-hidden">
-        {list.map((ele, idx) => {
-          return (
-            <div key={idx} className={`flex-1 ${idx === 0 ? "" : "border-l"}`}>
-              <div className="text-center py-[28px] border-b text-black font-bold">
-                {ele}
+      <div className="bg-white w-full h-[140px] flex flex-row justify-center items-center rounded-3xl overflow-hidden">
+        {cashData ? (
+          list.map((ele, idx) => {
+            return (
+              <div
+                key={idx}
+                className={`flex-1 ${idx === 0 ? "" : "border-l"}`}
+              >
+                <div className="text-center py-[28px] border-b text-black font-bold">
+                  {ele}
+                </div>
+                <div className="text-center py-[28px]">{ele}</div>
               </div>
-              <div className="text-center py-[28px]">{ele}</div>
-            </div>
-          );
-        })}
+            );
+          })
+        ) : (
+          <NoSettingData />
+        )}
       </div>
     </div>
   );

--- a/src/components/ExchangeRateSection/ExchangeRate.tsx
+++ b/src/components/ExchangeRateSection/ExchangeRate.tsx
@@ -1,9 +1,15 @@
 import React from "react";
 import { useGetExchangeRate } from "../../hook/useGetExchangeRate";
 import NoSettingData from "../common/NoSettingData";
+import { useRecoilState } from "recoil";
+import { destinationData } from "../../store/destinationAtom";
+import { toNumberCash } from "../../Util/calcCash";
 
 const ExchangeRate = () => {
-  const { cashData } = useGetExchangeRate();
+  const [DestinationData] = useRecoilState(destinationData);
+  const country = DestinationData?.planInfo.destination || "";
+
+  const { cashData } = useGetExchangeRate(country);
 
   const list: number[] = [1, 100, 1000, 2000, 5000, 10000, 50000];
 
@@ -29,12 +35,14 @@ const ExchangeRate = () => {
             return (
               <div
                 key={idx}
-                className={`flex-1 ${idx === 0 ? "" : "border-l"}`}
+                className={`flex-1 ${idx === 0 ? "" : "border-l"} text-[14px]`}
               >
-                <div className="text-center py-[28px] border-b text-black font-bold">
-                  {ele}
+                <div className="text-center py-[22px] border-b text-black font-bold">
+                  {ele} {cashData.exc}
                 </div>
-                <div className="text-center py-[28px]">{ele}</div>
+                <div className="text-center py-[22px]">
+                  {ele * toNumberCash(cashData.krw)} 원
+                </div>
               </div>
             );
           })

--- a/src/components/MainDashboard.tsx
+++ b/src/components/MainDashboard.tsx
@@ -28,7 +28,7 @@ const MainDashboard = () => {
           </div>
           <div className="h-full flex flex-col col-span-2 gap-7 ">
             <div>
-              <ExchangeRate country="싱가포르" />
+              <ExchangeRate />
             </div>
             <div className="h-full grid grid-cols-2 gap-4 pb-[40px]">
               <Accommodation />

--- a/src/context/selectBox/SelectInput.tsx
+++ b/src/context/selectBox/SelectInput.tsx
@@ -47,11 +47,7 @@ const SelectInput = ({
         onClick={(e) => {
           e.currentTarget.value.trim() ? handleList(true) : handleList(!isOn);
         }}
-        // readOnly={selected.label ? true : false}
         {...register("destination", { required: "destination is required" })}
-        onBlur={(e) => {
-          e.currentTarget.value.trim() ? handleList(true) : handleList(!isOn);
-        }}
       />
       {isOn && children}
     </div>

--- a/src/hook/useCountries.ts
+++ b/src/hook/useCountries.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { Country, Data, getCountries } from "../api/country";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export const useCountries = () => {
   const [value, setValue] = useState<Data[]>([]);
@@ -11,11 +11,13 @@ export const useCountries = () => {
   });
 
   const search = (str: string) => {
-    const searched = data?.data.filter(
-      (ele) => str && ele.한글명.includes(str)
-    );
+    const searched = data?.data.filter((ele) => ele.한글명.includes(str));
     setValue(searched || []);
   };
+
+  useEffect(() => {
+    if (data) setValue(data.data);
+  }, [data?.data]);
 
   return { value, search };
 };

--- a/src/hook/useGetExchangeRate.ts
+++ b/src/hook/useGetExchangeRate.ts
@@ -1,6 +1,8 @@
 import { AxiosError } from "axios";
 import { getExchangeList } from "../api/exchange";
 import { useQuery } from "@tanstack/react-query";
+import { useRecoilState } from "recoil";
+import { destinationData } from "../store/destinationAtom";
 
 type Cash = {
   result: number;
@@ -18,19 +20,21 @@ type Cash = {
 
 type CashData = Cash[];
 
-export const useGetExchangeRate = (kor: string) => {
+export const useGetExchangeRate = () => {
+  const [DestinationData] = useRecoilState(destinationData);
+  const country = DestinationData.apiParams.countryCodes;
   //리액트 쿼리로 해당 환율목록 가져오기
   const { data: cashData } = useQuery<
     CashData,
     AxiosError,
     { krw: string; exc: string }
   >({
-    queryKey: [`test2`],
+    queryKey: [`${country}`],
     queryFn: () => getExchangeList(),
     throwOnError: false,
     select: (res) => {
       const exchange = res.find((ele) => {
-        return ele.cur_nm.split(" ")[0] === kor;
+        return ele.cur_nm.split(" ")[0] === country;
       });
 
       return {

--- a/src/hook/useGetExchangeRate.ts
+++ b/src/hook/useGetExchangeRate.ts
@@ -22,8 +22,9 @@ type CashData = Cash[];
 
 export const useGetExchangeRate = () => {
   const [DestinationData] = useRecoilState(destinationData);
-  const country = DestinationData.apiParams.countryCodes;
+  const country = DestinationData?.apiParams?.countryCodes || "";
   //리액트 쿼리로 해당 환율목록 가져오기
+
   const { data: cashData } = useQuery<
     CashData,
     AxiosError,
@@ -33,15 +34,14 @@ export const useGetExchangeRate = () => {
     queryFn: () => getExchangeList(),
     throwOnError: false,
     select: (res) => {
-      const exchange = res.find((ele) => {
-        return ele.cur_nm.split(" ")[0] === country;
-      });
+      const exchange = res.find((ele) => ele.cur_nm.split(" ")[0] === country);
 
       return {
         krw: exchange ? exchange.bkpr : "",
         exc: exchange ? exchange.cur_nm.split(" ")[1] : ""
       };
-    }
+    },
+    enabled: Boolean(country)
   });
 
   //가져온 환율 목록 중 여행할 나라 환율 추출

--- a/src/hook/useGetExchangeRate.ts
+++ b/src/hook/useGetExchangeRate.ts
@@ -1,8 +1,6 @@
 import { AxiosError } from "axios";
 import { getExchangeList } from "../api/exchange";
 import { useQuery } from "@tanstack/react-query";
-import { useRecoilState } from "recoil";
-import { destinationData } from "../store/destinationAtom";
 
 type Cash = {
   result: number;
@@ -20,9 +18,7 @@ type Cash = {
 
 type CashData = Cash[];
 
-export const useGetExchangeRate = () => {
-  const [DestinationData] = useRecoilState(destinationData);
-  const country = DestinationData?.apiParams?.countryCodes || "";
+export const useGetExchangeRate = (country: string) => {
   //리액트 쿼리로 해당 환율목록 가져오기
 
   const { data: cashData } = useQuery<
@@ -45,6 +41,5 @@ export const useGetExchangeRate = () => {
   });
 
   //가져온 환율 목록 중 여행할 나라 환율 추출
-
   return { cashData };
 };


### PR DESCRIPTION

## 🔎 작업 내용

- input 을 눌렀을 때와 입력값을 전부 지웠을 때 모든 리스트 아이템 조회되도록.
1. 나라 조회 hook에 useEffect로 맨 처음부터 모든 리스트 아이템을 저장하기
2. debounce 의 스트링 조건문 제거 

  <br/>

## 이미지 첨부

<img width="496" alt="스크린샷 2024-05-15 오전 1 55 24" src="https://github.com/FE-MWM/WanderGuide/assets/89734122/c837d751-0bd4-4da4-b9be-06c33fc2ad8e">


<br/>

## 🔧 고민이 되는 부분이나 중점적으로 리뷰받고 싶은 부분 (옵션)

 input에 입력값이 없는 경우는 input을 클릭하는 것으로 리스트를 접었다 폈다 할 수 있습니다.
 input이 아닌 곳을 누르면 리스트가 접히지 않습니다.

  <br/>

