### PR TITLE
[86] feat : 환율 정보가 없는 경우의 UI 추가

### DIFF
--- a/src/Util/calcCash.ts
+++ b/src/Util/calcCash.ts
@@ -1,5 +1,13 @@
 export const toNumberCash = (cash: string) => {
+  //금액에 붙은 소수점이나 콤마 모두 제거
   const stringCash = cash.split(".")[0].replaceAll(",", "");
   const numberCash = Number(stringCash);
   return numberCash;
+};
+
+export const calcCash = (cash: string, rate: number) => {
+  const exchangeRate = toNumberCash(cash) * rate;
+
+  //3자리 수 마다 콤마 추가하는 정규식 적용
+  return exchangeRate.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 };

--- a/src/Util/calcCash.ts
+++ b/src/Util/calcCash.ts
@@ -1,0 +1,5 @@
+export const toNumberCash = (cash: string) => {
+  const stringCash = cash.split(".")[0].replaceAll(",", "");
+  const numberCash = Number(stringCash);
+  return numberCash;
+};

--- a/src/components/CountriesSelectBox.tsx
+++ b/src/components/CountriesSelectBox.tsx
@@ -1,11 +1,8 @@
-import { useRef } from "react";
 import SelectBox from "../context/selectBox/SelectBox";
-import { Data } from "../api/country";
 import { useCountries } from "../hook/useCountries";
 
 const CountriesSelectBox = () => {
   const { value, search } = useCountries();
-  const dataRef = useRef<Data | undefined>();
 
   return (
     <SelectBox>
@@ -21,7 +18,6 @@ const CountriesSelectBox = () => {
                 key={idx}
                 value={`${ele["ISO numeric"]}`}
                 label={ele.한글명}
-                onClick={() => (dataRef.current = ele)}
               >
                 {ele.한글명}
               </SelectBox.item>

--- a/src/components/ExchangeRateSection/ExchangeRate.tsx
+++ b/src/components/ExchangeRateSection/ExchangeRate.tsx
@@ -1,11 +1,8 @@
 import React from "react";
 import { useGetExchangeRate } from "../../hook/useGetExchangeRate";
 
-type ExchangeRateProps = {
-  country: string;
-};
-const ExchangeRate = ({ country }: ExchangeRateProps) => {
-  const { cashData } = useGetExchangeRate(country);
+const ExchangeRate = () => {
+  const { cashData } = useGetExchangeRate();
 
   const list: number[] = [1, 100, 1000, 2000, 5000, 10000, 50000];
 

--- a/src/components/ExchangeRateSection/ExchangeRate.tsx
+++ b/src/components/ExchangeRateSection/ExchangeRate.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useGetExchangeRate } from "../../hook/useGetExchangeRate";
+import NoExchangeRate from "./NoExchangeRate";
 import NoSettingData from "../common/NoSettingData";
 import { useRecoilState } from "recoil";
 import { destinationData } from "../../store/destinationAtom";
@@ -30,22 +31,26 @@ const ExchangeRate = () => {
         </div> */}
       </div>
       <div className="bg-white w-full h-[140px] flex flex-row justify-center items-center rounded-3xl overflow-hidden">
-        {cashData ? (
-          list.map((ele, idx) => {
-            return (
-              <div
-                key={idx}
-                className={`flex-1 ${idx === 0 ? "" : "border-l"} text-[13px]`}
-              >
-                <div className="text-center py-[22px] border-b text-black font-bold">
-                  {ele} {cashData.exc}
+        {country ? (
+          cashData?.krw && cashData?.exc ? (
+            list.map((ele, idx) => {
+              return (
+                <div
+                  key={idx}
+                  className={`flex-1 ${idx === 0 ? "" : "border-l"} text-[13px]`}
+                >
+                  <div className="text-center py-[22px] border-b text-black font-bold">
+                    {ele} {cashData.exc}
+                  </div>
+                  <div className="text-center py-[22px]">
+                    {calcCash(cashData.krw, ele)}원
+                  </div>
                 </div>
-                <div className="text-center py-[22px]">
-                  {calcCash(cashData.krw, ele)}원
-                </div>
-              </div>
-            );
-          })
+              );
+            })
+          ) : (
+            <NoExchangeRate />
+          )
         ) : (
           <NoSettingData />
         )}

--- a/src/components/ExchangeRateSection/ExchangeRate.tsx
+++ b/src/components/ExchangeRateSection/ExchangeRate.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useGetExchangeRate } from "../../hook/useGetExchangeRate";
+import NoSettingData from "../common/NoSettingData";
 
 const ExchangeRate = () => {
   const { cashData } = useGetExchangeRate();
@@ -22,17 +23,24 @@ const ExchangeRate = () => {
           <span className="text-xs pl-1">2024.04.20 19:30</span>
         </div> */}
       </div>
-      <div className="bg-white w-full flex flex-row rounded-3xl overflow-hidden">
-        {list.map((ele, idx) => {
-          return (
-            <div key={idx} className={`flex-1 ${idx === 0 ? "" : "border-l"}`}>
-              <div className="text-center py-[28px] border-b text-black font-bold">
-                {ele}
+      <div className="bg-white w-full h-[140px] flex flex-row justify-center items-center rounded-3xl overflow-hidden">
+        {cashData ? (
+          list.map((ele, idx) => {
+            return (
+              <div
+                key={idx}
+                className={`flex-1 ${idx === 0 ? "" : "border-l"}`}
+              >
+                <div className="text-center py-[28px] border-b text-black font-bold">
+                  {ele}
+                </div>
+                <div className="text-center py-[28px]">{ele}</div>
               </div>
-              <div className="text-center py-[28px]">{ele}</div>
-            </div>
-          );
-        })}
+            );
+          })
+        ) : (
+          <NoSettingData />
+        )}
       </div>
     </div>
   );

--- a/src/components/ExchangeRateSection/ExchangeRate.tsx
+++ b/src/components/ExchangeRateSection/ExchangeRate.tsx
@@ -3,7 +3,7 @@ import { useGetExchangeRate } from "../../hook/useGetExchangeRate";
 import NoSettingData from "../common/NoSettingData";
 import { useRecoilState } from "recoil";
 import { destinationData } from "../../store/destinationAtom";
-import { toNumberCash } from "../../Util/calcCash";
+import { calcCash } from "../../Util/calcCash";
 
 const ExchangeRate = () => {
   const [DestinationData] = useRecoilState(destinationData);
@@ -35,13 +35,13 @@ const ExchangeRate = () => {
             return (
               <div
                 key={idx}
-                className={`flex-1 ${idx === 0 ? "" : "border-l"} text-[14px]`}
+                className={`flex-1 ${idx === 0 ? "" : "border-l"} text-[13px]`}
               >
                 <div className="text-center py-[22px] border-b text-black font-bold">
                   {ele} {cashData.exc}
                 </div>
                 <div className="text-center py-[22px]">
-                  {ele * toNumberCash(cashData.krw)} 원
+                  {calcCash(cashData.krw, ele)}원
                 </div>
               </div>
             );

--- a/src/components/ExchangeRateSection/ExchangeRate.tsx
+++ b/src/components/ExchangeRateSection/ExchangeRate.tsx
@@ -1,9 +1,15 @@
 import React from "react";
 import { useGetExchangeRate } from "../../hook/useGetExchangeRate";
 import NoSettingData from "../common/NoSettingData";
+import { useRecoilState } from "recoil";
+import { destinationData } from "../../store/destinationAtom";
+import { toNumberCash } from "../../Util/calcCash";
 
 const ExchangeRate = () => {
-  const { cashData } = useGetExchangeRate();
+  const [DestinationData] = useRecoilState(destinationData);
+  const country = DestinationData?.planInfo.destination || "";
+
+  const { cashData } = useGetExchangeRate(country);
 
   const list: number[] = [1, 100, 1000, 2000, 5000, 10000, 50000];
 
@@ -29,12 +35,14 @@ const ExchangeRate = () => {
             return (
               <div
                 key={idx}
-                className={`flex-1 ${idx === 0 ? "" : "border-l"}`}
+                className={`flex-1 ${idx === 0 ? "" : "border-l"} text-[14px]`}
               >
-                <div className="text-center py-[28px] border-b text-black font-bold">
-                  {ele}
+                <div className="text-center py-[22px] border-b text-black font-bold">
+                  {ele} {cashData.exc}
                 </div>
-                <div className="text-center py-[28px]">{ele}</div>
+                <div className="text-center py-[22px]">
+                  {ele * toNumberCash(cashData.krw)} 원
+                </div>
               </div>
             );
           })

--- a/src/components/ExchangeRateSection/NoExchangeRate.tsx
+++ b/src/components/ExchangeRateSection/NoExchangeRate.tsx
@@ -1,0 +1,14 @@
+const NoExchangeRate = () => {
+  return (
+    <div className="h-full flex justify-center items-center">
+      <img
+        className="w-[24px] h-[24px]"
+        src="/images/plane-blue.svg"
+        alt="plane-icon"
+      />
+      <span className="text-cool-gray text-sm">환율 정보가 없습니다</span>
+    </div>
+  );
+};
+
+export default NoExchangeRate;

--- a/src/components/MainDashboard.tsx
+++ b/src/components/MainDashboard.tsx
@@ -28,7 +28,7 @@ const MainDashboard = () => {
           </div>
           <div className="h-full flex flex-col col-span-2 gap-7 ">
             <div>
-              <ExchangeRate country="싱가포르" />
+              <ExchangeRate />
             </div>
             <div className="h-full grid grid-cols-2 gap-4 pb-[40px]">
               <Accommodation />

--- a/src/context/selectBox/SelectInput.tsx
+++ b/src/context/selectBox/SelectInput.tsx
@@ -47,11 +47,7 @@ const SelectInput = ({
         onClick={(e) => {
           e.currentTarget.value.trim() ? handleList(true) : handleList(!isOn);
         }}
-        // readOnly={selected.label ? true : false}
         {...register("destination", { required: "destination is required" })}
-        onBlur={(e) => {
-          e.currentTarget.value.trim() ? handleList(true) : handleList(!isOn);
-        }}
       />
       {isOn && children}
     </div>

--- a/src/hook/useCountries.ts
+++ b/src/hook/useCountries.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { Country, Data, getCountries } from "../api/country";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export const useCountries = () => {
   const [value, setValue] = useState<Data[]>([]);
@@ -11,11 +11,13 @@ export const useCountries = () => {
   });
 
   const search = (str: string) => {
-    const searched = data?.data.filter(
-      (ele) => str && ele.한글명.includes(str)
-    );
+    const searched = data?.data.filter((ele) => ele.한글명.includes(str));
     setValue(searched || []);
   };
+
+  useEffect(() => {
+    if (data) setValue(data.data);
+  }, [data?.data]);
 
   return { value, search };
 };

--- a/src/hook/useCountries.ts
+++ b/src/hook/useCountries.ts
@@ -17,7 +17,7 @@ export const useCountries = () => {
 
   useEffect(() => {
     if (data) setValue(data.data);
-  }, [data?.data]);
+  }, [data]);
 
   return { value, search };
 };

--- a/src/hook/useGetExchangeRate.ts
+++ b/src/hook/useGetExchangeRate.ts
@@ -1,6 +1,8 @@
 import { AxiosError } from "axios";
 import { getExchangeList } from "../api/exchange";
 import { useQuery } from "@tanstack/react-query";
+import { useRecoilState } from "recoil";
+import { destinationData } from "../store/destinationAtom";
 
 type Cash = {
   result: number;
@@ -18,19 +20,21 @@ type Cash = {
 
 type CashData = Cash[];
 
-export const useGetExchangeRate = (kor: string) => {
+export const useGetExchangeRate = () => {
+  const [DestinationData] = useRecoilState(destinationData);
+  const country = DestinationData.apiParams.countryCodes;
   //리액트 쿼리로 해당 환율목록 가져오기
   const { data: cashData } = useQuery<
     CashData,
     AxiosError,
     { krw: string; exc: string }
   >({
-    queryKey: [`test2`],
+    queryKey: [`${country}`],
     queryFn: () => getExchangeList(),
     throwOnError: false,
     select: (res) => {
       const exchange = res.find((ele) => {
-        return ele.cur_nm.split(" ")[0] === kor;
+        return ele.cur_nm.split(" ")[0] === country;
       });
 
       return {

--- a/src/hook/useGetExchangeRate.ts
+++ b/src/hook/useGetExchangeRate.ts
@@ -22,8 +22,9 @@ type CashData = Cash[];
 
 export const useGetExchangeRate = () => {
   const [DestinationData] = useRecoilState(destinationData);
-  const country = DestinationData.apiParams.countryCodes;
+  const country = DestinationData?.apiParams?.countryCodes || "";
   //리액트 쿼리로 해당 환율목록 가져오기
+
   const { data: cashData } = useQuery<
     CashData,
     AxiosError,
@@ -33,15 +34,14 @@ export const useGetExchangeRate = () => {
     queryFn: () => getExchangeList(),
     throwOnError: false,
     select: (res) => {
-      const exchange = res.find((ele) => {
-        return ele.cur_nm.split(" ")[0] === country;
-      });
+      const exchange = res.find((ele) => ele.cur_nm.split(" ")[0] === country);
 
       return {
         krw: exchange ? exchange.bkpr : "",
         exc: exchange ? exchange.cur_nm.split(" ")[1] : ""
       };
-    }
+    },
+    enabled: Boolean(country)
   });
 
   //가져온 환율 목록 중 여행할 나라 환율 추출

--- a/src/hook/useGetExchangeRate.ts
+++ b/src/hook/useGetExchangeRate.ts
@@ -1,8 +1,6 @@
 import { AxiosError } from "axios";
 import { getExchangeList } from "../api/exchange";
 import { useQuery } from "@tanstack/react-query";
-import { useRecoilState } from "recoil";
-import { destinationData } from "../store/destinationAtom";
 
 type Cash = {
   result: number;
@@ -20,9 +18,7 @@ type Cash = {
 
 type CashData = Cash[];
 
-export const useGetExchangeRate = () => {
-  const [DestinationData] = useRecoilState(destinationData);
-  const country = DestinationData?.apiParams?.countryCodes || "";
+export const useGetExchangeRate = (country: string) => {
   //리액트 쿼리로 해당 환율목록 가져오기
 
   const { data: cashData } = useQuery<
@@ -45,6 +41,5 @@ export const useGetExchangeRate = () => {
   });
 
   //가져온 환율 목록 중 여행할 나라 환율 추출
-
   return { cashData };
 };


### PR DESCRIPTION

## 🔎 작업 내용

- 환율 정보가 없는 경우 메세지를 띄웁니다.

  <br/>

## 이미지 첨부

<img width="1225" alt="스크린샷 2024-05-15 오전 2 55 48" src="https://github.com/FE-MWM/WanderGuide/assets/89734122/06fd6732-e1d5-410d-9e1e-9f4f674732c3">


<br/>

## 🔧 고민이 되는 부분이나 중점적으로 리뷰받고 싶은 부분 (옵션)

- return 문 아래에서 이중 삼항 연산자로 컴포넌트를 분기 처리하고 있습니다....
복잡해 보이는 거 같은 데, 어떤 식으로 분기를 잡아야 더 가독성이 좋을지... 
좋은 아이디어 생각나면 바로 수정하겠습니다.

  <br/>

## ➕ 이슈 링크 (옵션)

- #86

<br/>