### PR TITLE
[112] feat: 예약탭으로 이동후에 다른 나라 여행지 선택했을 때 메인 탭으로 이동하도록 수정

### DIFF
--- a/src/api/exchange.ts
+++ b/src/api/exchange.ts
@@ -1,13 +1,9 @@
 import axios from "axios";
-import { getAbleDate, getFridayIfWeekend } from "../Util/calcExchangeDate";
 
-export const getExchangeList = async () => {
-  const today = getAbleDate().format("YYYY-MM-DD");
-  const checkWeekend = getFridayIfWeekend(today).format("YYYY-MM-DD");
+export const getExchangeList = async (date: string) => {
   try {
     const res = axios.get(
-      `https://www.koreaexim.go.kr/site/program/financial/exchangeJSON?authkey=${process.env.REACT_APP_API_EXCHANGE}&searchdate=${checkWeekend}&data=AP01`
-      //`/site/program/financial/exchangeJSON?authkey=YWVgIoxXxKTI3HNUAZYsfsrV9XTB0WIf&searchdate=20240423&data=AP01`
+      `https://www.koreaexim.go.kr/site/program/financial/exchangeJSON?authkey=${process.env.REACT_APP_API_EXCHANGE}&searchdate=${date}&data=AP01`
     );
     const req = await res;
     return req.data;

--- a/src/components/ExchangeRateSection/ExchangeRate.tsx
+++ b/src/components/ExchangeRateSection/ExchangeRate.tsx
@@ -10,9 +10,9 @@ const ExchangeRate = () => {
   const [DestinationData] = useRecoilState(destinationData);
   const country = DestinationData?.planInfo.destination || "";
 
-  const { cashData } = useGetExchangeRate(country);
+  const { cashData, checkWeekend } = useGetExchangeRate(country);
 
-  const list: number[] = [1, 100, 1000, 2000, 5000, 10000, 50000];
+  const list: number[] = [1, 2, 5, 10, 20, 50, 100];
 
   return (
     <div className="h-full flex flex-col">
@@ -20,15 +20,9 @@ const ExchangeRate = () => {
         <div>
           <span className="text-[22px] font-semibold pr-2">환율</span>
         </div>
-        {/*환율 새로고침 기능 주석 */}
-        {/* <div className="flex items-center">
-          <img
-            className="w-[20px] h-[20px]"
-            src="/images/refresh.svg"
-            alt="refresh"
-          />
-          <span className="text-xs pl-1">2024.04.20 19:30</span>
-        </div> */}
+        <div className="flex items-center">
+          <span className="text-xs pl-1">{checkWeekend} 기준 조회</span>
+        </div>
       </div>
       <div className="bg-white w-full h-[140px] flex flex-row justify-center items-center rounded-3xl overflow-hidden">
         {country ? (

--- a/src/components/ExchangeRateSection/ExchangeRate.tsx
+++ b/src/components/ExchangeRateSection/ExchangeRate.tsx
@@ -21,7 +21,12 @@ const ExchangeRate = () => {
           <span className="text-[22px] font-semibold pr-2">환율</span>
         </div>
         <div className="flex items-center">
-          <span className="text-xs pl-1">{checkWeekend} 기준 조회</span>
+          <img
+            className="w-[20px] h-[20px]"
+            src="/images/refresh.svg"
+            alt="refresh"
+          />
+          <span className="text-xs pl-1">{checkWeekend} 11:00</span>
         </div>
       </div>
       <div className="bg-white w-full h-[140px] flex flex-row justify-center items-center rounded-3xl overflow-hidden">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,9 +5,11 @@ import { PlanListData, planList } from "../store/planListAtom";
 import { useRecoilState, useSetRecoilState } from "recoil";
 import { getStoreData } from "../indexeddb/indexedDB";
 import { DestinationData, destinationData } from "../store/destinationAtom";
+import { useTab } from "../context/TabContext";
 
 const Navbar = () => {
   const { openModal, closeModal } = useModal();
+  const { setActiveTab } = useTab();
   const [list, setList] = useRecoilState<PlanListData[]>(planList);
   const setDestination = useSetRecoilState<DestinationData>(destinationData);
 
@@ -54,7 +56,10 @@ const Navbar = () => {
                 <div
                   key={item.id}
                   className={`flex items-center px-4 mb-[20px] ${item.isActive ? " border-l-blue-500 border-l-4" : ""} cursor-pointer`}
-                  onClick={() => handlePlanSelection(item.id)}
+                  onClick={() => {
+                    handlePlanSelection(item.id);
+                    setActiveTab("main");
+                  }}
                 >
                   <img
                     className="w-[40px] h-[40px]"

--- a/src/hook/useGetExchangeRate.ts
+++ b/src/hook/useGetExchangeRate.ts
@@ -1,6 +1,7 @@
 import { AxiosError } from "axios";
 import { getExchangeList } from "../api/exchange";
 import { useQuery } from "@tanstack/react-query";
+import { getAbleDate, getFridayIfWeekend } from "../Util/calcExchangeDate";
 
 type Cash = {
   result: number;
@@ -19,15 +20,17 @@ type Cash = {
 type CashData = Cash[];
 
 export const useGetExchangeRate = (country: string) => {
-  //리액트 쿼리로 해당 환율목록 가져오기
+  const today = getAbleDate().format("YYYY-MM-DD");
+  const checkWeekend = getFridayIfWeekend(today).format("YYYY-MM-DD");
 
+  //리액트 쿼리로 해당 환율목록 가져오기
   const { data: cashData } = useQuery<
     CashData,
     AxiosError,
     { krw: string; exc: string }
   >({
     queryKey: [`${country}`],
-    queryFn: () => getExchangeList(),
+    queryFn: () => getExchangeList(checkWeekend),
     throwOnError: false,
     select: (res) => {
       const exchange = res.find((ele) => ele.cur_nm.split(" ")[0] === country);
@@ -41,5 +44,5 @@ export const useGetExchangeRate = (country: string) => {
   });
 
   //가져온 환율 목록 중 여행할 나라 환율 추출
-  return { cashData };
+  return { cashData, checkWeekend };
 };

--- a/src/page/Home.tsx
+++ b/src/page/Home.tsx
@@ -36,15 +36,15 @@ const Home = () => {
     <div className="flex w-full h-full bg-[#f5f7fa]  min-h-[800px] min-w-[1500px]">
       {isReady && (
         <>
-          <nav className="w-[230px] h-full">
-            <Navbar />
-          </nav>
-          <main className="w-[calc(100%-260px)] h-full flex-1">
-            <Header />
-            <TabProvider>
+          <TabProvider>
+            <nav className="w-[230px] h-full">
+              <Navbar />
+            </nav>
+            <main className="w-[calc(100%-260px)] h-full flex-1">
+              <Header />
               <Body />
-            </TabProvider>
-          </main>
+            </main>
+          </TabProvider>
         </>
       )}
     </div>


### PR DESCRIPTION



## 🔎 작업 내용

- 다른 나라를 클릭하면 자동으로 메인탭으로 이동합니다
- 환율 조회 기준 날짜 표시 추가하였습니다
- 환율 계산 범위를 수정하였습니다 

  <br/>

## 이미지 첨부

( 메인 탭으로 이동하는 건 스크린샷으로 못남겼어요ㅠㅠ!!)

<img width="817" alt="스크린샷 2024-05-16 오후 6 04 02" src="https://github.com/FE-MWM/WanderGuide/assets/89734122/d8c7c7dd-beac-479a-add7-188c555f2c94">


<br/>


## ➕ 이슈 링크 (옵션)

- #112 

<br/>
