### PR TITLE
[115][133] feat: 공통 confirm modal 구현

### DIFF
--- a/src/components/BookingSection/ActivityItem.tsx
+++ b/src/components/BookingSection/ActivityItem.tsx
@@ -9,6 +9,7 @@ import {
   destinationData
 } from "../../store/destinationAtom";
 import { updateData } from "../../indexeddb/indexedDB";
+import ConfirmModal from "../common/ConfirmModal";
 
 type PropsData = {
   data: {
@@ -26,6 +27,7 @@ type DateInfo = {
 
 const ActivityItem = ({ data: { id, date, memo } }: PropsData) => {
   const [dateInfo, setDateInfo] = useState<DateInfo>();
+  const [isConfirmModalOpen, setConfirmModalOpen] = useState(false);
   const { openModal } = useModal();
   const [data, setData] = useRecoilState<DestinationData>(destinationData);
   const activityData = useRecoilValue<Activities[]>(activities);
@@ -56,11 +58,7 @@ const ActivityItem = ({ data: { id, date, memo } }: PropsData) => {
     openModal("액티비티/투어", <ActivityModal id={id} />);
   };
 
-  const handleDeleteActivity = (
-    event: React.MouseEvent<HTMLImageElement, MouseEvent>
-  ) => {
-    event.stopPropagation();
-
+  const handleConfirm = () => {
     const filterData = activityData.filter((data) => data.id !== id);
 
     const parseData = {
@@ -72,36 +70,55 @@ const ActivityItem = ({ data: { id, date, memo } }: PropsData) => {
     updateData(data.id as number, parseData);
   };
 
+  const handleDeleteActivity = (
+    event: React.MouseEvent<HTMLImageElement, MouseEvent>
+  ) => {
+    event.stopPropagation();
+
+    setConfirmModalOpen(true);
+  };
+
   useEffect(() => {
     const dateInfo = formatDate(date);
     setDateInfo(dateInfo);
   }, [date]);
   return (
-    <div
-      className="bg-white w-full rounded-3xl p-4 mt-[28px] flex items-center justify-between cursor-pointer relative"
-      onClick={() => handleUpdateActivity()}
-    >
-      <div className="w-[60px] flex flex-col items-center justify-center">
-        <span className="text-sm text-cool-gray">{dateInfo?.yearMonth}</span>
-        <span className="text-3xl text-cool-gray-dart font-bold">
-          {dateInfo?.day}
-        </span>
-        <span className="text-sm text-cool-gray">{dateInfo?.dayOfWeek}</span>
-      </div>
-      <div className="w-[calc(100%-84px)] pl-4 pr-2">
-        <p>{memo}</p>
-      </div>
-      <div className=" w-[30px] flex items-center justify-center">
-        <div className="absolute top-[25px] right-[30px]">
-          <img
-            src="/images/close.svg"
-            alt="close"
-            className="w-[15px] h-[15px] cursor-pointer"
-            onClick={(event) => handleDeleteActivity(event)}
-          />
+    <>
+      <div
+        className="bg-white w-full rounded-3xl p-4 mt-[28px] flex items-center justify-between cursor-pointer relative"
+        onClick={() => handleUpdateActivity()}
+      >
+        <div className="w-[60px] flex flex-col items-center justify-center">
+          <span className="text-sm text-cool-gray">{dateInfo?.yearMonth}</span>
+          <span className="text-3xl text-cool-gray-dart font-bold">
+            {dateInfo?.day}
+          </span>
+          <span className="text-sm text-cool-gray">{dateInfo?.dayOfWeek}</span>
+        </div>
+        <div className="w-[calc(100%-84px)] pl-4 pr-2">
+          <p>{memo}</p>
+        </div>
+        <div className=" w-[30px] flex items-center justify-center">
+          <div className="absolute top-[25px] right-[30px]">
+            <img
+              src="/images/close.svg"
+              alt="close"
+              className="w-[15px] h-[15px] cursor-pointer"
+              onClick={(event) => handleDeleteActivity(event)}
+            />
+          </div>
         </div>
       </div>
-    </div>
+      {isConfirmModalOpen && (
+        <ConfirmModal
+          type="confirm"
+          imageType="delete"
+          message="삭제하시겠습니까?"
+          onConfirm={handleConfirm}
+          onCancel={() => setConfirmModalOpen(false)}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+
+type ConfirmModalProps = {
+  type: "confirm" | "alert";
+  imageType?: "info" | "delete";
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export default function ConfirmModal({
+  type,
+  imageType,
+  message,
+  onConfirm,
+  onCancel
+}: ConfirmModalProps) {
+  const getImageSrc = () => {
+    switch (imageType) {
+      case "delete":
+        return "/images/delete.svg";
+      case "info":
+      default:
+        return "";
+    }
+  };
+
+  return (
+    <div className="overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full md:inset-0 h-full bg-gray-800 bg-opacity-50">
+      <div className="bg-white rounded-lg w-[340px] h-[200px]">
+        <div className="w-full h-full grid grid-rows-[1fr,70px] justify-center p-4">
+          <div
+            className={`flex flex-col items-center ${imageType ? "justify-end" : "justify-center"}`}
+          >
+            {imageType && (
+              <div className="mb-4">
+                <img src={getImageSrc()} alt="" className="w-8 h-8" />
+              </div>
+            )}
+            <p className="font-bold text-xl">{message}</p>
+          </div>
+          <div className="flex justify-center items-end">
+            {type === "confirm" && (
+              <button
+                className="text-gray-900 bg-white hover:bg-gray-100 border border-gray-200 font-bold px-10 py-2 rounded mr-2"
+                onClick={onCancel}
+              >
+                취소
+              </button>
+            )}
+            <button
+              className="text-white bg-blue-700 hover:bg-blue-800 border border-blue-700 font-bold px-10 py-2 rounded"
+              onClick={onConfirm}
+            >
+              확인
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- [133] feat: 공통 confirm modal 구현

## 🔎 작업 내용

- 공통으로 사용될 confirm modal 구현

  <br/>

## 이미지 첨부
**confirm일 경우**

![스크린샷 2024-07-02 00 50 12](https://github.com/FE-MWM/WanderGuide/assets/58253184/10fb885a-141f-47d3-a178-6408ec415445)
![스크린샷 2024-07-02 00 50 27](https://github.com/FE-MWM/WanderGuide/assets/58253184/991f5382-5cf6-4124-9f73-ce2c48154359)

**alert일 경우**
![스크린샷 2024-07-02 00 51 55](https://github.com/FE-MWM/WanderGuide/assets/58253184/cfd8f95d-397b-4611-874f-fb85927dc6fc)


<br/>

## 🔧 고민이 되는 부분이나 중점적으로 리뷰받고 싶은 부분 (옵션)

- 아래 보시면 type 으로 confirm 또는 alert 을 받고 imageType은 옵션인데 아이콘을 삽입 할 수 있습니다. 
(쓰다보니 image 보다는 iconType 으로 변경하는게 더 좋겠네요)
이대로 계속 진행할까하는데 어떠신가요?
```
type ConfirmModalProps = {
  type: "confirm" | "alert";
  imageType?: "info" | "delete";
  message: string;
  onConfirm: () => void;
  onCancel: () => void;
};
```

  <br/>

## 🔧 앞으로의 과제 (옵션)

- 버튼도 색상도 기본적으로 몇가지 정해놓고 취소, 확인 부분 색상 변경 가능하도록 추가 개발도 생각중입니다.

  <br/>

## ➕ 이슈 링크 (옵션)

- [레포 이름 #133 ]

<br/>
